### PR TITLE
XTE-301, XTE-319, XTE-322

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 6.9.4 - 2017-02-13
+- XTE-301: Security Server UI bugfix: race condition of the adding a new client caused duplicates
+- XTE-319: Security Server UI bugfix: WSDL deletion caused incorrect ACL removal
+- XTE-322: Security Server bugfix: a typo in the configuration file proxy.ini (client-timeout)
+
 ## 6.9.3 - 2017-02-10
 - PVAYLADEV-691: Hotfix for ExecListingSensor init. (Fixes package listing information, etc)
 

--- a/xtee6/build.gradle
+++ b/xtee6/build.gradle
@@ -30,7 +30,7 @@ sonarqube {
         property "sonar.projectKey", "xtee6"
         property "sonar.projectName", "X-Road"
         property "sonar.projectDescription", "National Data Exchange Layer"
-        property "sonar.projectVersion", "6.9.3"    }
+        property "sonar.projectVersion", "6.9.4"    }
 }
 
 allprojects {

--- a/xtee6/packages/build-jetty-rpm.sh
+++ b/xtee6/packages/build-jetty-rpm.sh
@@ -30,7 +30,7 @@ if [[ ! -f $(basename $JETTY) || "$md5a" != "$md5b" ]]; then
 fi
 cd ..
 rpmbuild \
-    --define "xroad_version 6.9.3" \
+    --define "xroad_version 6.9.4" \
     --define "jetty $JETTY" \
     --define "rel $RELEASE" \
     --define "snapshot .$SNAPSHOT" \

--- a/xtee6/packages/build-xroad-rpm.sh
+++ b/xtee6/packages/build-xroad-rpm.sh
@@ -11,7 +11,7 @@ CMD=${2-bb}
 rm -rf ${ROOT}/RPMS/*
 
 rpmbuild \
-    --define "xroad_version 6.9.3" \
+    --define "xroad_version 6.9.4" \
     --define "rel $RELEASE" \
     --define "snapshot .$SNAPSHOT" \
     --define "_topdir $ROOT" \

--- a/xtee6/packages/default-configuration/proxy.ini
+++ b/xtee6/packages/default-configuration/proxy.ini
@@ -16,7 +16,7 @@ client-http-port=80
 client-https-port=443
 
 ; Client Proxy to Server Proxy connection timeout in milliseconds
-client-timout=300000
+client-timeout=300000
 
 ; Port number for Server Proxy as seen from Client Proxy
 server-port=5500

--- a/xtee6/packages/xroad-jetty9/debian/changelog
+++ b/xtee6/packages/xroad-jetty9/debian/changelog
@@ -1,3 +1,9 @@
+xroad-jetty9 (6.9.4) trusty; urgency=low
+
+  * Version bump
+
+ -- Cybernetica AS <xroad-support@cyber.ee>  Mon, 13 Feb 2017 18:36:28 +0200
+
 xroad-jetty9 (6.9.3) trusty; urgency=low
 
   * Version bump

--- a/xtee6/packages/xroad/debian/changelog
+++ b/xtee6/packages/xroad/debian/changelog
@@ -1,3 +1,11 @@
+xroad (6.9.4) trusty; urgency=low
+  
+  * XTE-301: Security Server UI bugfix: race condition of the adding a new client caused duplicates
+  * XTE-319: Security Server UI bugfix: WSDL deletion caused incorrect ACL removal
+  * XTE-322: Security Server bugfix: a typo in the configuration file proxy.ini (client-timeout)
+
+ -- Cybernetica AS <xroad-support@cyber.ee>  Mon, 13 Feb 2017 18:36:28 +0200
+
 xroad (6.9.3) trusty; urgency=low
 
   * PVAYLADEV-691: Hotfix for ExecListingSensor init. (Fixes package listing information, etc)

--- a/xtee6/proxy-ui/app/controllers/clients_controller.rb
+++ b/xtee6/proxy-ui/app/controllers/clients_controller.rb
@@ -34,6 +34,8 @@ class ClientsController < ApplicationController
   include Clients::Services
   include Clients::AclSubjects
 
+  @@lock_client_add = Mutex.new
+
   def index
     authorize!(:view_clients)
 
@@ -154,6 +156,8 @@ class ClientsController < ApplicationController
       :member_name => member_name
     })
   end
+
+  synchronize :client_add, :with => :@@lock_client_add
 
   def client_certs
     authorize!(:view_client_details)


### PR DESCRIPTION
* XTE-301: Security Server UI bugfix: race condition of the adding a new client caused duplicates
* XTE-319: Security Server UI bugfix: WSDL deletion caused incorrect ACL removal
* XTE-322: Security Server bugfix: a typo in the configuration file proxy.ini (client-timeout)